### PR TITLE
se ha agregado los skills para este proyecto

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,16 @@
+# HydraClone Skills Catalog
+
+Estructura según “agent skills”: cada skill vive en su carpeta con un `README.md` que define objetivo, pasos y ejemplo de uso (comandos listos para ejecutar).
+
+Skills incluidas:
+- `bootstrap/` — preparar entorno y dependencias.
+- `layout/` — validar estructura de proyecto y rutas generadas.
+- `run/` — ejecutar HydraClone con credenciales y salidas esperadas.
+- `release/` — checklist para cortes de versión.
+- `upgrade/` — migrar desde v1.x (rutas antiguas) a la versión actual.
+
+Uso general:
+```
+cd skills/<skill>
+cat README.md
+```

--- a/skills/bootstrap/README.md
+++ b/skills/bootstrap/README.md
@@ -1,0 +1,29 @@
+# Skill: Bootstrap HydraClone
+
+## Objetivo
+Dejar el entorno listo (venv, deps, .env) para ejecutar HydraClone sin dependencias externas.
+
+## Pasos
+1) Crear y activar venv:
+```
+python3 -m venv venv
+source venv/bin/activate
+```
+2) Instalar dependencias:
+```
+pip install --upgrade pip setuptools wheel
+pip install -r requirements.txt
+```
+3) Configurar entorno:
+```
+cp .env.example .env    # editar tokens opcional
+```
+
+## Salidas esperadas
+- venv/ creado.
+- `.env` presente.
+
+## Ejemplo de uso
+```
+bash -lc "cd /home/dev/leo/hydra-clone && python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt && cp .env.example .env"
+```

--- a/skills/layout/README.md
+++ b/skills/layout/README.md
@@ -1,0 +1,28 @@
+# Skill: Layout HydraClone
+
+## Objetivo
+Verificar que la estructura y rutas generadas estén dentro del proyecto.
+
+## Estructura esperada
+```
+hydra-clone/
+├─ src/            # main.py, config.py
+├─ modules/        # auth, clone, reports, animations...
+├─ scripts/        # install.sh, run.sh, test.sh
+├─ docs/           # documentación
+├─ clones/TS/      # salida de clonaciones (runtime)
+├─ reports/        # reportes MD (runtime)
+├─ config/.credentials/ # credenciales JSON (runtime, gitignored)
+├─ .env / .env.example
+├─ requirements.txt
+└─ venv/ (local)
+```
+
+## Checks rápidos
+- `config/.credentials/` existe o se crea en runtime y está gitignored.
+- `clones/` y `reports/` se crean dentro del repo (no en `~/`).
+
+## Ejemplo de validación
+```
+bash -lc "cd /home/dev/leo/hydra-clone && ls src modules scripts docs clones reports config/.credentials"
+```

--- a/skills/release/README.md
+++ b/skills/release/README.md
@@ -1,0 +1,27 @@
+# Skill: Release HydraClone
+
+## Objetivo
+Publicar una versión estable con checklist reproducible.
+
+## Pasos
+1) Bump de versión en `src/config.py` (y README si aplica).
+2) Changelog: actualizar `docs/CAMBIOS.md` con fecha y cambios.
+3) Docs: asegurar `INDEX.md`, `QUICKSTART.md`, `USAGE.md` reflejan rutas actuales (clones/FECHA_HORA, reports/, config/.credentials/).
+4) Dependencias: revisar/actualizar `requirements.txt`; recrear venv si cambia.
+5) Smoke manual:
+```
+source venv/bin/activate
+python3 src/main.py   # clonar 1 repo público
+```
+   Verifica que cree `clones/TS/...` y `reports/clone-report_*.md`.
+6) Gitignore: confirmar `config/.credentials/` y `clones/` siguen ignorados.
+7) Tag (si aplica):
+```
+git tag vX.Y.Z
+git push --tags
+```
+
+## Ejemplo de checklist en un comando
+```
+bash -lc "cd /home/dev/leo/hydra-clone && source venv/bin/activate && python3 - <<'PY'\nprint('Smoke: ejecutar main.py y validar clones/reportes dentro del repo')\nPY"
+```

--- a/skills/run/README.md
+++ b/skills/run/README.md
@@ -1,0 +1,29 @@
+# Skill: Ejecutar HydraClone
+
+## Objetivo
+Levantar la CLI, autenticar y generar clones/reportes dentro del proyecto.
+
+## Pasos
+1) Activar entorno:
+```
+source venv/bin/activate
+```
+2) Ejecutar CLI:
+```
+bash scripts/run.sh
+# o
+python3 src/main.py
+```
+3) Ingresar URLs (http/https/ssh). Detecta plataformas automáticamente.
+4) Credenciales:
+   - Usa `.env` si existen tokens.
+   - Si no, las solicita y guarda en `config/.credentials/credentials.json` (chmod 600).
+
+## Salidas esperadas
+- Repos: `clones/FECHA_HORA/<plataforma>/<repo>`
+- Reporte: `reports/clone-report_YYYY-MM-DD_HH-MM-SS.md`
+
+## Ejemplo de uso
+```
+bash -lc "cd /home/dev/leo/hydra-clone && source venv/bin/activate && python3 src/main.py"
+```

--- a/skills/upgrade/README.md
+++ b/skills/upgrade/README.md
@@ -1,0 +1,27 @@
+# Skill: Upgrade/Migración HydraClone
+
+## Objetivo
+Migrar desde v1.x (clones y credenciales fuera del repo) a la estructura actual.
+
+## Pasos
+1) Mover clones previos (si existen):
+```
+mkdir -p clones/TS/github
+cp -r ~/clones/github/* clones/TS/github/    # ajustar TS y plataforma
+```
+2) Migrar credenciales previas:
+```
+mkdir -p config/.credentials
+cp ~/.hydra-clone/credentials.json config/.credentials/  # opcional
+chmod 600 config/.credentials/credentials.json
+```
+3) Asegurar ignores:
+- `config/.credentials/`
+- `clones/`
+
+4) Revisar docs: rutas internas (clones/FECHA_HORA, reports/, config/.credentials/).
+
+## Ejemplo de uso
+```
+bash -lc "cd /home/dev/leo/hydra-clone && mkdir -p clones/2026-03-30_00-00-00/github && cp -r ~/clones/github/* clones/2026-03-30_00-00-00/github/ 2>/dev/null || true"
+```


### PR DESCRIPTION
This pull request introduces a new "skills catalog" for HydraClone, providing clear, modular documentation for key workflows such as bootstrapping, running, validating layout, releasing, and upgrading the project. Each skill is documented in its own directory with a `README.md` that defines its objective, steps, and example usage, making it easier for developers to follow best practices and automate common tasks.

**Skills Catalog Structure and Documentation:**

* Added a top-level `skills/README.md` that describes the catalog structure and lists included skills, with instructions for usage.

**Individual Skill Guides:**

* Bootstrap:
  - Added `skills/bootstrap/README.md` detailing how to set up the environment, install dependencies, and configure `.env`, with example commands and expected outputs.
* Layout:
  - Added `skills/layout/README.md` specifying the expected project directory structure and quick validation steps.
* Run:
  - Added `skills/run/README.md` explaining how to activate the environment, run the CLI, handle credentials, and verify outputs.
* Release:
  - Added `skills/release/README.md` with a reproducible checklist for publishing a stable release, including version bump, changelog, documentation, dependency checks, manual smoke test, gitignore verification, and tagging.
* Upgrade:
  - Added `skills/upgrade/README.md` guiding migration from v1.x to the new structure, including moving previous clones and credentials, updating gitignore, and reviewing documentation.